### PR TITLE
Add attribute self.visible_fields

### DIFF
--- a/flet_contrib/color_picker/src/color_picker.py
+++ b/flet_contrib/color_picker/src/color_picker.py
@@ -10,10 +10,16 @@ CIRCLE_SIZE = 20
 
 
 class ColorPicker(ft.Column):
-    def __init__(self, color="#000000", width=COLOR_MATRIX_WIDTH):
+    def __init__(
+            self, 
+            color="#000000", 
+            width=COLOR_MATRIX_WIDTH,
+            visible_fields=False
+        ):
         super().__init__()
         self.tight = True
         self.width = width
+        self.visible_fields = visible_fields
         self.__color = color
         self.hue_slider = HueSlider(
             on_change_hue=self.update_color_picker_on_hue_change,
@@ -118,6 +124,7 @@ class ColorPicker(ft.Column):
                     ],
                 ),
                 ft.Row(
+                    visible=self.visible_fields,
                     alignment=ft.MainAxisAlignment.SPACE_AROUND,
                     controls=[
                         self.hex,


### PR DESCRIPTION
An attribute that hides manually inputted data for color determination.

Another aspect is that when I'm developing an application on my personal smartphone, using ColorPicker breaks the graphics. At that moment, I don't need TextFields at all

<img src="https://github.com/flet-dev/flet-contrib/assets/105982046/d71156b1-1ab8-44d4-a398-f31023dd9678" width="200" />
<img src="https://github.com/flet-dev/flet-contrib/assets/105982046/a6ddbbef-be60-47bb-836a-8d16bc54268f" width="200" />

Result:
<img src="https://github.com/flet-dev/flet-contrib/assets/105982046/f9be9d56-f9ca-45dd-886d-aa4aa90e46a0" width="200" />

